### PR TITLE
Fix crash when profiling without performancemonitor resource

### DIFF
--- a/library/profile_profil.c
+++ b/library/profile_profil.c
@@ -103,6 +103,11 @@ profil(unsigned short *buffer, size_t bufSize, size_t offset, unsigned int scale
 
 	if (buffer == 0)
 	{
+		if (!IPM)
+		{
+			return 0;
+		}
+
 		Stack = SuperState();
 		IPM->EventControlTags(
 			PMECT_Disable, 			PMEC_MasterInterrupt,


### PR DESCRIPTION
Using gcc profiling feature (with option -pg) relies on events obtained
thanks to the performancemonitor resource that is not available on all
machines, on which that caused a crash trying to use profiling.
This fix was done in newlib but not in clib2 yet.